### PR TITLE
get_error_messages_from_paramもコンテキストを見るように

### DIFF
--- a/lib/FormValidator/Lite.pm
+++ b/lib/FormValidator/Lite.pm
@@ -195,7 +195,7 @@ sub get_error_messages_from_param {
         $dup_check{"$param.$func"}++;
     }
 
-    return @messages;
+    return wantarray ? @messages : \@messages;
 }
 
 1;


### PR DESCRIPTION
get_error_messagesと同様にget_error_messages_from_paramもwantarrayみるようにしてあるのでよろしくお願いします！
