### PR TITLE
get_error_message の $gen_msg を method に

### DIFF
--- a/lib/FormValidator/Lite.pm
+++ b/lib/FormValidator/Lite.pm
@@ -170,20 +170,20 @@ sub get_error_message {
     my $err_function = $msg->{function}->{$function};
     
     if ($err_message) {
-        return $self->_gen_msg($err_message, $err_param);
+        return $self->build_message($err_message, $err_param);
     } elsif ($err_function && $err_param) {
-        return $self->_gen_msg($err_function, $err_param);
+        return $self->build_message($err_function, $err_param);
     } else {
         Carp::carp  "${param}.${function} is not defined in message file.";
         if ($msg->{default_tmpl}) {
-            return $self->_gen_msg($err_function || $msg->{default_tmpl}, $err_function || $param);
+            return $self->build_message($err_function || $msg->{default_tmpl}, $err_function || $param);
         } else {
             return '';
         }
     }
 }
 
-sub _gen_msg {
+sub build_message {
     my ($self, $tmpl, @args) = @_;
     local $_ = $tmpl;
     s!\[_(\d+)\]!$args[$1-1]!ge;
@@ -405,8 +405,12 @@ Set an error message for a given $param and $func pair.
     ...
 
 Set the error message map. In the 'function' and 'message' sections,
-C<< [_1] >> will be replaced with the description of the failing parameter
-provided in the 'param' section.
+C<< [_1] >> will be replaced by C<< build_message >> with the description of
+the failing parameter provided in the 'param' section.
+
+=item C<< $validator->build_message($tmpl, @args) >>
+
+replace [_1] in C<< $tmpl >> by C<< @args >>.
 
 Setup error message map.
 

--- a/t/010_core/013_build_message.t
+++ b/t/010_core/013_build_message.t
@@ -1,0 +1,9 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More tests => 1;
+use FormValidator::Lite;
+
+my $v = FormValidator::Lite->new({});
+my $m = $v->build_message("[_1] is [_2]", "foo", "bar");
+is $m, "foo is bar";


### PR DESCRIPTION
formvalidator::lite を wrap したものを使ってる時に error_message を生成するときに Locale::Maketext::Lexicon の localize とかでやりたい事があるので差し替えられるようにメソッドにしました。

``` perl
MyApp::FormVlidator;
use parent 'FormVlidator::Lite';

sub _gen_msg {
    my ($self, $tmpl, @args);
    MyApp->context->localize($tmpl, @args);
}

1;
```

みたいに挙動を変えたいのです。どうでしょうか。
