### PR TITLE
Make 'message' parameter for set_message_data() optional.

### DIFF
--- a/lib/FormValidator/Lite.pm
+++ b/lib/FormValidator/Lite.pm
@@ -130,7 +130,7 @@ sub set_param_message {
 
 sub set_message_data {
     my ($self, $msg) = @_;
-    for my $key (qw/message param function/) {
+    for my $key (qw/param function/) {
         Carp::croak("missing key $key") unless $msg->{$key};
     }
     $self->{_msg} = $msg;


### PR DESCRIPTION
In current implementation, the 'message' parameter is mandatory for set_message_data().
IMHO it's too strict.
Error messages can be constructed with 'param' and 'function'.
