### PR TITLE
Fix Hash::MultiValue hash handling

### DIFF
--- a/lib/FormValidator/Lite/Hash.pm
+++ b/lib/FormValidator/Lite/Hash.pm
@@ -8,6 +8,7 @@ sub new {
     my $class = shift;
     my @args = @_==1 ? %{$_[0]} : @_;
     my $self = bless {}, $class;
+    # for Hash::MultiValue hash
     while (my ($k, $v) = splice @args, 0, 2) {
         push @{$self->{$k}}, $v;
     }

--- a/t/999_regression/003_break_multivalue_hash.t
+++ b/t/999_regression/003_break_multivalue_hash.t
@@ -12,8 +12,8 @@ my $q = Hash::MultiValue->new(
 
 my $validator = FormValidator::Lite->new($q);
 
-is(join(' ', sort @{ $validator->query->{a} }), '1 2');
-is(join(' ', sort @{ $validator->query->{b} }), '2');
+is(join(' ', sort $validator->query->param('a')), '1 2');
+is(join(' ', sort $validator->query->param('b')), '2');
 
 done_testing;
 


### PR DESCRIPTION
コンストラクタにHash::MultiValueなハッシュを直に与えた場合に同じキーの値が上書きされてしまうようなので修正しました。
