### PR TITLE
make CGI.pm a test-phase dependency.

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,3 @@
-requires 'CGI', '3.31,!=4.05,!=4.06,!=4.07,!=4.08';
 requires 'Class::Accessor::Lite', '0.05';
 requires 'Class::Load', '0.11';
 requires 'Email::Valid';
@@ -8,6 +7,7 @@ requires 'Scalar::Util', '1.19';
 requires 'perl', '5.008001';
 
 on test => sub {
+    requires 'CGI', '3.31,!=4.05,!=4.06,!=4.07,!=4.08';
     requires 'Test::Base::Less';
     requires 'Test::More', '0.98';
     requires 'Test::Requires', '0.05';

--- a/lib/FormValidator/Lite.pm
+++ b/lib/FormValidator/Lite.pm
@@ -74,7 +74,7 @@ sub check {
 sub _extract_values {
     my ($self, $key) = @_;
 
-    local $CGI::LIST_CONTEXT_WARN = 0;
+    local $CGI::LIST_CONTEXT_WARN = 0 if %CGI::;
     my $q = $self->{query};
     my @values;
     if (ref $key) {


### PR DESCRIPTION
Since this module really does not depend on CGI.pm in the runtime, it makes sense to not declare it as runtime dependency.

This means, we shouldn't need to accquire CGI.pm from CPAN when upgrading perl for a plack-based $project.  However, having CGI.pm declared as runtime dependency in META.json means that all CPAN toolchain that you can use to install app dependencies simply install CGI.pm before it installs FormValidator::Lite.