### PR TITLE
Add flag rule

### DIFF
--- a/lib/FormValidator/Lite/Constraint/Default.pm
+++ b/lib/FormValidator/Lite/Constraint/Default.pm
@@ -103,6 +103,8 @@ rule 'FILTER' => sub {
     1; # always return true
 };
 
+rule 'FLAG' => sub { $_ =~ /^[01]$/ };
+
 1;
 __END__
 

--- a/lib/FormValidator/Lite/Constraint/Default.pm
+++ b/lib/FormValidator/Lite/Constraint/Default.pm
@@ -227,5 +227,13 @@ FILTER is special constraint. It does not check the value and simply filter.
 "trim" is only pre-defined. You can also pass a callback.
 Callback takes parameter as first argument, should return filtered value.
 
+=item FLAG
+
+    $validator->check(
+        is_enabled => [qw/FLAG/]
+    );
+
+Check parameter is 0 or 1.
+
 =back
 

--- a/t/020_constraints/001_default.t
+++ b/t/020_constraints/001_default.t
@@ -261,3 +261,20 @@ __END__
     foo => 0,
     bar => 0,
 )
+
+=== FLAG
+--- query: { z1 => 0, z2 => 1, z3 => 2, z4 => 'foo' }
+--- rule
+(
+    z1 => [qw/FLAG/],
+    z2 => [qw/FLAG/],
+    z3 => [qw/FLAG/],
+    z4 => [qw/FLAG/],
+)
+--- expected
+(
+    z1 => 0,
+    z2 => 0,
+    z3 => 1,
+    z4 => 1,
+)


### PR DESCRIPTION
Can check it with `['CHOICE(IN)' => [0, 1]`, but I thought it would be useful to have a definition, so I added a flag rule.